### PR TITLE
Only call alerts js when necessary

### DIFF
--- a/openy_node_alert.libraries.yml
+++ b/openy_node_alert.libraries.yml
@@ -2,10 +2,10 @@ alert:
   version: 1.0
   js:
     js/openy-alerts/build/main.js: {preprocess: false}
-    js/openy_node_alert.js: {}
+    js/openy_node_alert.js: {preprocess: false}
   css:
     component:
-      js/openy-alerts/build/main.css: {preprocess: true}
+      js/openy-alerts/build/main.css: {preprocess: false}
   dependencies:
     - core/drupal
     - core/jquery

--- a/openy_node_alert.module
+++ b/openy_node_alert.module
@@ -12,7 +12,13 @@ use Drupal\Core\Cache\Cache;
  * Implements hook_preprocess_node().
  */
 function openy_node_alert_preprocess_page(&$variables) {
-  $variables['#attached']['library'][] = 'openy_node_alert/alert';
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node instanceof \Drupal\node\NodeInterface) {
+    [$sendAlerts, $alerts] = \Drupal::service('openy_node_alert.alert_manager')->getAlerts($node);
+    if ($sendAlerts) {
+      $variables['#attached']['library'][] = 'openy_node_alert/alert';
+    }
+  }
 }
 
 /**

--- a/openy_node_alert.services.yml
+++ b/openy_node_alert.services.yml
@@ -1,6 +1,6 @@
 services:
   openy_node_alert.alert_manager:
     class: 'Drupal\openy_node_alert\Service\AlertManager'
-    arguments: ['@entity_type.manager']
+    arguments: ['@entity_type.manager', '@current_user', '@path_alias.manager', '@path.matcher']
     tags:
       - { name: service_collector, tag: alert_builder, call: addBuilder }

--- a/src/Service/AlertManager.php
+++ b/src/Service/AlertManager.php
@@ -285,6 +285,11 @@ class AlertManager {
         return $state === 'include';
       }
     }
-    return FALSE;
+
+    // If the code got to this point, then no path matches were found. This
+    // means we have to hide the alert (return FALSE) if it has "include"
+    // visibility state. And show the alert (return TRUE) with the "exclude"
+    // state.
+    return $state !== 'include';
   }
 }

--- a/src/Service/AlertManager.php
+++ b/src/Service/AlertManager.php
@@ -275,13 +275,21 @@ class AlertManager {
     $current_path = $this->aliasManager->getAliasByPath('/node/'.$node->id());
     $current_path = mb_strtolower($current_path);
     // Check all values from the field "alert_visibility_pages".
+    $hide_exclude = FALSE;
     foreach ($pages as $page) {
       $page_path = $page === '<front>' ? '/' : '/' . ltrim($page, '/');
       $is_path_match = $this->pathMatcher->matchPath($current_path, $page_path);
-      if ($state == 'include' && $is_path_match || $state == 'exclude' && !$is_path_match) {
-        // Local alert.
+      if ($state == 'include' && $is_path_match) {
+        // Show alert in a first possible match.
         return TRUE;
       }
+      if ($state == 'exclude' && $is_path_match) {
+        $hide_exclude = TRUE;
+      }
+    }
+    // Check for exclude, current path is not in list of pages for exclude.
+    if ($state == 'exclude' && !$hide_exclude) {
+      return TRUE;
     }
     return FALSE;
   }

--- a/src/Service/AlertManager.php
+++ b/src/Service/AlertManager.php
@@ -275,21 +275,15 @@ class AlertManager {
     $current_path = $this->aliasManager->getAliasByPath('/node/'.$node->id());
     $current_path = mb_strtolower($current_path);
     // Check all values from the field "alert_visibility_pages".
-    $hide_exclude = FALSE;
     foreach ($pages as $page) {
       $page_path = $page === '<front>' ? '/' : '/' . ltrim($page, '/');
       $is_path_match = $this->pathMatcher->matchPath($current_path, $page_path);
-      if ($state == 'include' && $is_path_match) {
-        // Show alert in a first possible match.
-        return TRUE;
+      if ($is_path_match) {
+        // If this path matches at least one of the visibility pages,
+        // we return TRUE if we want to include the alert on this page.
+        // Hide the alert on the given page otherwise.
+        return $state === 'include';
       }
-      if ($state == 'exclude' && $is_path_match) {
-        $hide_exclude = TRUE;
-      }
-    }
-    // Check for exclude, current path is not in list of pages for exclude.
-    if ($state == 'exclude' && !$hide_exclude) {
-      return TRUE;
     }
     return FALSE;
   }

--- a/src/Service/AlertManager.php
+++ b/src/Service/AlertManager.php
@@ -4,7 +4,11 @@ namespace Drupal\openy_node_alert\Service;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Path\PathMatcherInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\path_alias\AliasManagerInterface;
 
 
 /**
@@ -36,12 +40,41 @@ class AlertManager {
   protected $nodeStorage;
 
   /**
+   * A current user instance.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The alias manager that caches alias lookups based on the request.
+   *
+   * @var \Drupal\path_alias\AliasManagerInterface
+   */
+  protected $aliasManager;
+
+  /**
+   * The Path Matcher.
+   *
+   * @var \Drupal\Core\Path\PathMatcherInterface
+   */
+  protected $pathMatcher;
+
+  /**
    * Constructs the Alert manager.
    *
    * @param EntityTypeManagerInterface $entity_type_manager
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    AccountProxyInterface $current_user,
+    AliasManagerInterface $alias_manager,
+    PathMatcherInterface $path_matcher
+  ) {
     $this->nodeStorage = $entity_type_manager->getStorage('node');
+    $this->currentUser = $current_user;
+    $this->aliasManager = $alias_manager;
+    $this->pathMatcher = $path_matcher;
   }
 
   /**
@@ -83,7 +116,7 @@ class AlertManager {
    * @return array
    *   The array alert ids to display on page.
    */
-  public function getAlerts(EntityInterface $node) {
+  public function getServiceAlerts(EntityInterface $node) {
     if (!$this->alertsSorted) {
       $this->alertsSorted = $this->sortAlerts();
     }
@@ -106,4 +139,150 @@ class AlertManager {
     return $alerts;
   }
 
+  /**
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \HttpException
+   */
+  public function getAlerts(EntityInterface $node) {
+    // Get data from draggableviews_structure table.
+    $query = \Drupal::database()->select('draggableviews_structure', 'dvs');
+    $query->fields('dvs', ['view_name', 'view_display', 'entity_id', 'weight']);
+    $query->condition('dvs.view_name', 'alerts_rearrange');
+    $query->condition('dvs.view_display', 'page_1');
+    $query->orderBy('dvs.weight');
+    $weights = $query->execute()->fetchAll();
+    $loadByProperties = ['type' => 'alert', 'status' => 1];
+
+    $alerts_entities = $this->nodeStorage
+      ->loadByProperties($loadByProperties);
+
+    $alerts = $alerts_entities;
+
+    // Sort alert based on draggable_views data.
+    if (!empty($weights)) {
+      $alerts = [];
+      foreach ($weights as $row) {
+        if (!isset($alerts_entities[(int)$row->entity_id])) {
+          continue;
+        }
+        $alerts[] = $alerts_entities[(int)$row->entity_id];
+        unset($alerts_entities[(int)$row->entity_id]);
+      }
+      // Add items that was missed in draggableviews table.
+      $alerts = array_merge($alerts, $alerts_entities);
+    }
+
+    $service_alert_ids = $this->getServiceAlerts($node);
+    $sendAlerts = [];
+    /** @var \Drupal\node\Entity\Node $alert */
+    foreach ($alerts as $alert) {
+      // Filter alerts to remove alerts not listed by alert service for this uri.
+      if (!empty($service_alert_ids) && !in_array($alert->id(), $service_alert_ids)) {
+        continue;
+      }
+      if (!$alert->hasField('field_alert_visibility_pages')) {
+        if ($alert->hasField('field_alert_belongs') && !$alert->field_alert_belongs->isEmpty() && !$alert->field_alert_place->isEmpty()) {
+          $refid = $alert->field_alert_belongs->target_id;
+          $alias = $this->aliasManager->getAliasByPath('/node/' . $refid);
+          if ($_GET['uri'] != $alias) {
+            // Do not show alerts for current page.
+            continue;
+          }
+          $sendAlerts[$alert->field_alert_place->value]['local'][] = $this->formatAlert($alert);
+        }
+        elseif ($alert->hasField('field_alert_belongs') && $alert->field_alert_belongs->isEmpty() && !$alert->field_alert_place->isEmpty()) {
+          $sendAlerts[$alert->field_alert_place->value]['global'][] = $this->formatAlert($alert);
+        }
+        else {
+          throw new \HttpException('Field configuration for alerts is wrong');
+        }
+      }
+      elseif ($this->checkVisibility($alert, $node)) {
+        $sendAlerts[$alert->field_alert_place->value]['local'][] = $this->formatAlert($alert);
+      }
+      else {
+        if ($alert->hasField('field_alert_location') && !$alert->field_alert_location->isEmpty()) {
+          $sendAlerts[$alert->field_alert_place->value]['local'][] = $this->formatAlert($alert);
+        }
+      }
+    }
+
+    return [$sendAlerts, $alerts];
+  }
+
+  /**
+   * Helper function for alerts formatting.
+   *
+   * @param \Drupal\node\NodeInterface $alert
+   *   Alert node.
+   *
+   * @return array
+   *   Formatted alert.
+   */
+  public function formatAlert(NodeInterface $alert) {
+    $url = $alert->field_alert_link->uri != NULL ? Url::fromUri($alert->field_alert_link->uri)
+      ->setAbsolute()
+      ->toString() : NULL;
+
+    $iconColor = '';
+    if ($alert->field_alert_icon_color && $alert->field_alert_icon_color->entity && $alert->field_alert_icon_color->entity->field_color && $alert->field_alert_icon_color->entity->field_color->value) {
+      $iconColor = $alert->field_alert_icon_color->entity->field_color->value;
+    }
+
+    return [
+      'title' => $alert->getTitle(),
+      'textColor' => $alert->field_alert_text_color->entity->field_color->value,
+      'bgColor' => $alert->field_alert_color->entity->field_color->value,
+      'description' => $alert->field_alert_description->value,
+      'iconColor' => $iconColor,
+      'linkUrl' => $url,
+      'linkText' => $alert->field_alert_link->title,
+      'id' => $alert->id(),
+    ];
+  }
+
+  /**
+   * Check visibility of alert.
+   *
+   * @param \Drupal\node\NodeInterface $alert
+   *   Alert node.
+   *
+   * @return bool
+   *   Visibility status, TRUE if visible.
+   */
+  private function checkVisibility(NodeInterface $alert, NodeInterface $node) {
+    $visibility_paths = '';
+    if ($alert->hasField('field_alert_visibility_pages')) {
+      $visibility_paths = $alert->get('field_alert_visibility_pages')->value;
+    }
+
+    $state = 'include';
+    if ($alert->hasField('field_alert_visibility_state')) {
+      $state = $alert->get('field_alert_visibility_state')->value;
+    }
+
+    $visibility_paths = mb_strtolower($visibility_paths);
+    $pages = preg_split("(\r\n?|\n)", $visibility_paths);
+
+    if (empty($visibility_paths) || empty($pages)) {
+      // Global alert.
+      return TRUE;
+    }
+    // Convert path to lowercase. This allows comparison of the same path.
+    // with different case. Ex: /Page, /page, /PAGE.
+    // Compare the lowercase path alias (if any) and internal path.
+    $current_path = $this->aliasManager->getAliasByPath('/node/'.$node->id());
+    $current_path = mb_strtolower($current_path);
+    // Check all values from the field "alert_visibility_pages".
+    foreach ($pages as $page) {
+      $page_path = $page === '<front>' ? '/' : '/' . ltrim($page, '/');
+      $is_path_match = $this->pathMatcher->matchPath($current_path, $page_path);
+      if ($state == 'include' && $is_path_match || $state == 'exclude' && !$is_path_match) {
+        // Local alert.
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
 }


### PR DESCRIPTION
Backport patch from YMCA Dayton and reapply recent patches.

To test:
- clear caches, ensure js aggregation is off 
- with no alerts published, observe `main.js` is not loaded
- publish an alert (maybe clear caches?), observe `main.js` is loaded and the alert is properly displayed.