### PR TITLE
fix: Edit entity presave logic

### DIFF
--- a/openy_node_alert.module
+++ b/openy_node_alert.module
@@ -57,7 +57,7 @@ function openy_node_alert_entity_presave(EntityInterface $entity) {
         }
       }
     }
-    
+
     // Collecting nodes from the Reference field.
     if (
       $entity->hasField('field_alert_belongs')

--- a/openy_node_alert.module
+++ b/openy_node_alert.module
@@ -37,20 +37,27 @@ function openy_node_alert_entity_presave(EntityInterface $entity) {
       && !$entity->get('field_alert_visibility_pages')->isEmpty()
     ) {
 
-      $visibility_paths = $entity->get('field_alert_visibility_pages')->getValue();
+      // Trim any leading or trailing spaces as they can cause false positives.
+      $visibility_paths = trim($entity->get('field_alert_visibility_pages')->value);
+      $entity->field_alert_visibility_pages->value = $visibility_paths;
+
+      // Convert path to lowercase. This allows comparison of the same path.
+      // with different case. Ex: /Page, /page, /PAGE.
+      $visibility_paths = mb_strtolower($visibility_paths);
+      $pages = preg_split("(\r\n?|\n)", $visibility_paths);
+
       $path_matcher = \Drupal::service('path_alias.manager');
       $cacheTags = [];
-      foreach ($visibility_paths as $visibility_path) {
-        $canonical_path = $path_matcher->getPathByAlias($visibility_path['value']);
+      foreach ($pages as $page) {
+        $canonical_path = $path_matcher->getPathByAlias($page);
         // Check if this path is a node path.
         if (strpos($canonical_path, 'node') !== FALSE) {
           $nid = explode('/', $canonical_path)[2];
           $cacheTags[] = 'node:' . $nid;
-
         }
       }
     }
-
+    
     // Collecting nodes from the Reference field.
     if (
       $entity->hasField('field_alert_belongs')


### PR DESCRIPTION
Related to [#2578](https://github.com/ymcatwincities/openy/issues/2578)

This resolves two issues:

1. Extra line break in "Visibility Pages" field can cause alerts to appear on the homepage
    - Due to this logic, https://github.com/open-y-subprojects/openy_node_alert/blob/e77122811529d70cb5f914a75686cc932ef6ccbf/src/Service/AlertManager.php#L279, the empty string matches with `/`. By trimming it we're removing that possibility.
 2. Cache tags were not properly invalidated on Alert save
     - On xdebug inspection, `$entity->get('field_alert_visibility_pages')->getValue()` was returning a nested array that we weren't splitting properly, so it would never match `getPathByAlias`. This splits the paths properly using the same logic as `checkVisibility` above.