### PR TITLE
Include HTTPException and fix syntax

### DIFF
--- a/src/Plugin/rest/resource/AlertsRestResource.php
+++ b/src/Plugin/rest/resource/AlertsRestResource.php
@@ -198,7 +198,7 @@ class AlertsRestResource extends ResourceBase {
     $uri = $this->request->query->get('uri');
     $result = $this->router->match($uri);
     if (!isset($result['node'])) {
-      throw new HttpException(400, 'Node not found');
+      return new ModifiedResourceResponse('Node not found');
     }
     [$sendAlerts, $alerts] = $this->alertManager->getAlerts($result['node']);
 

--- a/src/Plugin/rest/resource/AlertsRestResource.php
+++ b/src/Plugin/rest/resource/AlertsRestResource.php
@@ -15,7 +15,6 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 
 /**

--- a/src/Plugin/rest/resource/AlertsRestResource.php
+++ b/src/Plugin/rest/resource/AlertsRestResource.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 
 /**
@@ -197,7 +198,7 @@ class AlertsRestResource extends ResourceBase {
     $uri = $this->request->query->get('uri');
     $result = $this->router->match($uri);
     if (!isset($result['node'])) {
-      throw new \HttpException('Node not found');
+      throw new HttpException(400, 'Node not found');
     }
     [$sendAlerts, $alerts] = $this->alertManager->getAlerts($result['node']);
 


### PR DESCRIPTION
as per https://api.drupal.org/api/drupal/vendor%21symfony%21http-kernel%21Exception%21HttpException.php/class/HttpException/9.2.x, HTTPException requires an int status code before the message.

Before this, requesting alerts for a url that doesn't exist, like `alerts?_format=json&uri=/user/reset/1/blah/blah/login` throws an error:

> Error: Class 'HttpException' not found in Drupal\openy_node_alert\Plugin\rest\resource\AlertsRestResource->get() (line 200 of /var/www/docroot/modules/contrib/openy_node_alert/src/Plugin/rest/resource/AlertsRestResource.php)

After this it still throws an exception, but a clean one. I wonder, though, if the node is not found should we just return an empty response instead so that we don't throw php errors?