### PR TITLE
Resolve deprecated warning for preg_split() function

### DIFF
--- a/src/Service/AlertManager.php
+++ b/src/Service/AlertManager.php
@@ -254,12 +254,18 @@ class AlertManager {
   private function checkVisibility(NodeInterface $alert, NodeInterface $node) {
     $visibility_paths = '';
     if ($alert->hasField('field_alert_visibility_pages')) {
-      $visibility_paths = $alert->get('field_alert_visibility_pages')->value;
+      $field = $alert->get('field_alert_visibility_pages');
+      if (!$field->isEmpty()) {
+        $visibility_paths = $field->getString();
+      }
     }
 
     $state = 'include';
     if ($alert->hasField('field_alert_visibility_state')) {
-      $state = $alert->get('field_alert_visibility_state')->value;
+      $field = $alert->get('field_alert_visibility_state');
+      if (!$field->isEmpty()) {
+        $state = $field->getString();
+      }
     }
 
     $visibility_paths = $visibility_paths ? mb_strtolower($visibility_paths) : $visibility_paths;


### PR DESCRIPTION
Deprecated function: preg_split(): Passing null to parameter #2 ($subject) of type string is deprecated in Drupal\openy_node_alert\Service\AlertManager->checkVisibility()

Null can appear in `preg_split` if 
`$visibility_paths = $alert->get('field_alert_visibility_pages')->value;` 
(taken from https://github.com/open-y-subprojects/openy_node_alert/blob/main/src/Service/AlertManager.php#L257)  returns `NULL` because the `field_alert_visibility_pages` is empty.

This commit aims to resolve this problem.


