### PR TITLE
Fix check for <front>

### DIFF
--- a/src/Service/AlertManager.php
+++ b/src/Service/AlertManager.php
@@ -283,7 +283,7 @@ class AlertManager {
     $current_path = $current_path ? mb_strtolower($current_path) : $current_path;
     // Check all values from the field "alert_visibility_pages".
     foreach ($pages as $page) {
-      $page_path = $page === '<front>' ? '/' : '/' . ltrim($page, '/');
+      $page_path = $page === '<front>' ? '<front>' : '/' . ltrim($page, '/');
       $is_path_match = $this->pathMatcher->matchPath($current_path, $page_path);
       if ($is_path_match) {
         // If this path matches at least one of the visibility pages,

--- a/src/Service/AlertManager.php
+++ b/src/Service/AlertManager.php
@@ -283,7 +283,7 @@ class AlertManager {
     $current_path = $current_path ? mb_strtolower($current_path) : $current_path;
     // Check all values from the field "alert_visibility_pages".
     foreach ($pages as $page) {
-      $page_path = $page === '<front>' ? '<front>' : '/' . ltrim($page, '/');
+      $page_path = ($page === '<front>' || $page === '/') ? '<front>' : '/' . ltrim($page, '/');
       $is_path_match = $this->pathMatcher->matchPath($current_path, $page_path);
       if ($is_path_match) {
         // If this path matches at least one of the visibility pages,


### PR DESCRIPTION
https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Path%21PathMatcher.php/function/PathMatcher%3A%3AmatchPath/9.3.x expects `<front>` not `/` for the homepage, so by rewriting the user input I believe we were causing `matchPath` to return `false` for `<front>`.