### PR TITLE
[DS-1074] Alert Rearrange is not added to admin menu

### DIFF
--- a/config/install/views.view.alerts_rearrange.yml
+++ b/config/install/views.view.alerts_rearrange.yml
@@ -369,9 +369,9 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.field_alert_place'
-  page_1:
+  list:
     display_plugin: page
-    id: page_1
+    id: list
     display_title: 'Alerts Rearrange'
     position: 1
     display_options:

--- a/openy_node_alert.install
+++ b/openy_node_alert.install
@@ -5,10 +5,9 @@
  * Open Y Node Alert install file.
  */
 
+use \Drupal\menu_link_content\Entity\MenuLinkContent;
 use \Drupal\user\Entity\Role;
 use \Drupal\user\RoleInterface;
-use \Drupal\Component\Utility\Unicode;
-use Drupal\field\Entity\FieldConfig;
 
 /**
  * Implements hook_install().
@@ -387,4 +386,17 @@ function openy_node_alert_update_8017() {
       $config_updater->update($config, $config_name, $param);
     }
   }
+}
+
+/**
+ * Update Rearranging Alerts views configuration.
+ */
+function openy_node_alert_update_8018() {
+  $config_dir = \Drupal::service('extension.list.module')->getPath('openy_node_alert') . '/config/install/';
+  $configs = [
+    'views.view.alerts_rearrange',
+  ];
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs($configs);
 }

--- a/openy_node_alert.links.menu.yml
+++ b/openy_node_alert.links.menu.yml
@@ -1,0 +1,5 @@
+openy_node_alert.alerts_rearrange:
+  title: 'Alerts Rearrange'
+  route_name: view.alerts_rearrange.list
+  parent: system.admin_content
+  weight: 0


### PR DESCRIPTION
- Go to the site as an admin user
- Open _/admin/content_ page
- Make sure that you can see 2 possible links on how to access **Alerts Rearrange** page: from the tab and admin menu (check the screenshots)

<img width="936" alt="image" src="https://github.com/open-y-subprojects/openy_node_alert/assets/14111296/7c12a12c-a196-42ab-baad-8e081535657d">
<img width="639" alt="image" src="https://github.com/open-y-subprojects/openy_node_alert/assets/14111296/d8a8365e-41a5-4c69-9fb4-e775e15b6b1a">
