### PR TITLE
DS-1228 fix: Ensure alerts are choosing order from the right view

### DIFF
--- a/src/Service/AlertManager.php
+++ b/src/Service/AlertManager.php
@@ -160,7 +160,7 @@ class AlertManager {
     $query = $this->connection->select('draggableviews_structure', 'dvs');
     $query->fields('dvs', ['view_name', 'view_display', 'entity_id', 'weight']);
     $query->condition('dvs.view_name', 'alerts_rearrange');
-    $query->condition('dvs.view_display', 'page_1');
+    $query->condition('dvs.view_display', 'list');
     $query->orderBy('dvs.weight');
     $weights = $query->execute()->fetchAll();
     $loadByProperties = ['type' => 'alert', 'status' => 1];


### PR DESCRIPTION
To test:
- rearrange alerts at /admin/content/alerts-rearrange
- observe change is reflected on the front-end