### PR TITLE
Ensure alert redirect respects base_path

### DIFF
--- a/src/Plugin/rest/resource/AlertsRestResource.php
+++ b/src/Plugin/rest/resource/AlertsRestResource.php
@@ -223,7 +223,11 @@ class AlertsRestResource extends ResourceBase {
 
     if ($language && !$request_language || $request_language && $request_language->getId() != $alert_language) {
       // Redirect to the same request URL with the language code added after the basePath.
-      $redirectUrl = $this->request->getSchemeAndHttpHost() . '/' . $langcode . $this->request->getRequestUri();
+      $base_path = $this->request->getBasePath();
+      $redirectUrl = $this->request->getSchemeAndHttpHost()
+        . $base_path . '/'
+        . $langcode
+        . str_replace($base_path, '', $this->request->getRequestUri()) ;
       // Sets the HTTP Status code to 303 - See Other.
       $response = new ModifiedResourceResponse(NULL, 303);
       $response->headers->set('Location', $redirectUrl);


### PR DESCRIPTION
#136 failed in QA builds (the links on https://github.com/YCloudYUSA/yusaopeny/pull/190) because it constructs a redirect based on `getSchemeAndHttpHost` but does not account for the Drupal site `basePath` if it exists. 

On the test url, the alerts query is redirected to `http://profile.openy.cibox.tools/fr/build4832/alerts?uri=/fr&_format=json`. In this case, `/fr` should be after`/build4832`.

This is a pretty rare case, but the build URLs (like `http://profile.openy.cibox.tools/build4832`) are a great test case for this.

This fix accounts for the base on the redirect, if it exists.