### PR TITLE
[DS-1766] Adds '#states' functionality to the add Alert node form.

### DIFF
--- a/openy_node_alert.module
+++ b/openy_node_alert.module
@@ -81,7 +81,26 @@ function openy_node_alert_entity_presave(EntityInterface $entity) {
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function openy_node_alert_form_node_alert_edit_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+function openy_node_alert_form_node_alert_edit_form_alter(array &$form, FormStateInterface $form_state, $form_id): void {
+  _openy_node_alert_alter_node_alert_form($form);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function openy_node_alert_form_node_alert_form_alter(array &$form, FormStateInterface $form_state, $form_id): void {
+  _openy_node_alert_alter_node_alert_form($form);
+}
+
+/**
+ * Adds '#states' functionality to the node form.
+ *
+ * @param $form
+ *   An object of the node form.
+ *
+ * @return void
+ */
+function _openy_node_alert_alter_node_alert_form(&$form): void {
   // Show these fields only for the classic style option.
   $fields_to_toggle = [
     'field_alert_color',


### PR DESCRIPTION
Jira: [DS-1766](https://yusa.atlassian.net/browse/DS-1766)

#### Steps for review
- [ ] log as admin
- [ ] go to /admin/modules
- [ ] enable the Small Y Alerts module
- [ ] hover over content > add content >click on Alert
- [ ] fill in required fields
- [ ] verify that you can see new options in the Alert Style field
- [ ] select Classic style
- [ ] verify that Fields for classic styles are displayed
- [ ] select other styles
- [ ] check if the Fields for classic styles are hidden