### PR TITLE
Support hidden alert color field widgets

### DIFF
--- a/openy_node_alert.module
+++ b/openy_node_alert.module
@@ -108,10 +108,12 @@ function _openy_node_alert_alter_node_alert_form(&$form): void {
   ];
 
   foreach ($fields_to_toggle as $field_name) {
-    $form[$field_name]['widget']['#states'] = [
-      'visible' => [
-        ':input[name="field_alert_style"]' => ['value' => 'classic'],
-      ],
-    ];
+    if (!empty($form[$field_name]['widget'])) {
+      $form[$field_name]['widget']['#states'] = [
+        'visible' => [
+          ':input[name="field_alert_style"]' => ['value' => 'classic'],
+        ],
+      ];
+    }
   }
 }

--- a/openy_node_alert.module
+++ b/openy_node_alert.module
@@ -109,11 +109,7 @@ function _openy_node_alert_alter_node_alert_form(&$form): void {
 
   foreach ($fields_to_toggle as $field_name) {
     if (!empty($form[$field_name]['widget'])) {
-      $form[$field_name]['widget']['#states'] = [
-        'visible' => [
-          ':input[name="field_alert_style"]' => ['value' => 'classic'],
-        ],
-      ];
+      $form[$field_name]['widget']['#states']['visible'][':input[name="field_alert_style"]']['value'] = 'classic';
     }
   }
 }


### PR DESCRIPTION
## Overview

- Support hidden alert color field widgets: support sites that don't always show the color field widgets when editing alerts.
- Don't overwrite color field widget `#states`: play nicely with other code that might also add states to the color field widgets.

## Details

If you hide the field widgets for any of the alert color fields you get a PHP warning due to processing the orphaned `#states`:

<details><summary>

`Warning: Undefined array key "#type" in Drupal\Core\Form\FormHelper::processStates() (line 211 of core/lib/Drupal/Core/Form/FormHelper.php).`

</summary>

```
Drupal\Core\Form\FormHelper::processStates() (Line: 447)
Drupal\Core\Render\Renderer->doRender() (Line: 493)
Drupal\Core\Render\Renderer->doRender() (Line: 493)
Drupal\Core\Render\Renderer->doRender() (Line: 240)
Drupal\Core\Render\Renderer->render() (Line: 483)
Drupal\Core\Template\TwigExtension->escapeFilter() (Line: 48)
__TwigTemplate_750fccce8b0b6309712ea23a1263ff1b->doDisplay() (Line: 393)
Twig\Template->yield() (Line: 349)
Twig\Template->display() (Line: 364)
Twig\Template->render() (Line: 35)
Twig\TemplateWrapper->render() (Line: 39)
twig_render_template() (Line: 348)
Drupal\Core\Theme\ThemeManager->render() (Line: 480)
Drupal\Core\Render\Renderer->doRender() (Line: 240)
Drupal\Core\Render\Renderer->render() (Line: 238)
Drupal\Core\Render\MainContent\HtmlRenderer->Drupal\Core\Render\MainContent\{closure}() (Line: 627)
Drupal\Core\Render\Renderer->executeInRenderContext() (Line: 239)
Drupal\Core\Render\MainContent\HtmlRenderer->prepare() (Line: 128)
Drupal\Core\Render\MainContent\HtmlRenderer->renderResponse() (Line: 90)
Drupal\Core\EventSubscriber\MainContentViewSubscriber->onViewRenderArray()
call_user_func() (Line: 111)
Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch() (Line: 186)
Symfony\Component\HttpKernel\HttpKernel->handleRaw() (Line: 76)
Symfony\Component\HttpKernel\HttpKernel->handle() (Line: 58)
Drupal\Core\StackMiddleware\Session->handle() (Line: 48)
Drupal\Core\StackMiddleware\KernelPreHandle->handle() (Line: 28)
Drupal\Core\StackMiddleware\ContentLength->handle() (Line: 106)
Drupal\page_cache\StackMiddleware\PageCache->pass() (Line: 85)
Drupal\page_cache\StackMiddleware\PageCache->handle() (Line: 58)
Drupal\openy_block_date\StackMiddleware\BlockDateCacheInvalidator->handle() (Line: 48)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle() (Line: 51)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle() (Line: 36)
Drupal\Core\StackMiddleware\AjaxPageState->handle() (Line: 51)
Drupal\Core\StackMiddleware\StackedHttpKernel->handle() (Line: 704)
Drupal\Core\DrupalKernel->handle() (Line: 19)
```

</details>

I believe caused by this:

https://github.com/open-y-subprojects/openy_node_alert/blob/90a3d58cc7947d44eec391faee7dec2008dd726d/openy_node_alert.module#L103-L116

I also thought it might make sense to avoid overwriting `#states` entirely, but instead try to make just the minimal change needed for the module to function. I think this will play more nicely with alterations from custom code or future contrib changes.

Thanks!