### PR TITLE
Set empty URI to string instead of null

### DIFF
--- a/src/Plugin/rest/resource/AlertsRestResource.php
+++ b/src/Plugin/rest/resource/AlertsRestResource.php
@@ -207,7 +207,7 @@ class AlertsRestResource extends ResourceBase {
       throw new AccessDeniedHttpException();
     }
 
-    $uri = $this->request->query->get('uri');
+    $uri = $this->request->query->get('uri') ?? '';
 
     // Extract the language code from the URI.
     $langcode = substr($uri, 1, 2);


### PR DESCRIPTION
In rare instances (like calling `/alerts` while testing), the request URI can be NULL. Passing NULL further down will cause errors. This sets `$uri` to an empty string instead of NULL as expected further down the function.