### PR TITLE
feat(ITCR-800): Allow location alerts to also show on Visibility Pages

### DIFF
--- a/src/Service/AlertManager.php
+++ b/src/Service/AlertManager.php
@@ -200,8 +200,14 @@ class AlertManager {
     /** @var \Drupal\node\Entity\Node $alert */
     foreach ($alerts as $alert) {
       // Filter alerts to remove alerts not listed by alert service for this uri.
+      // Allow location-based alerts through if they match the current page via
+      // Visibility Pages, so an alert can target both a location and specific pages.
       if (!empty($service_alert_ids) && !in_array($alert->id(), $service_alert_ids)) {
-        continue;
+        $hasLocation = $alert->hasField('field_alert_location')
+          && !$alert->field_alert_location->isEmpty();
+        if (!$hasLocation || !$this->checkVisibility($alert, $node)) {
+          continue;
+        }
       }
 
       // Load the translation content.


### PR DESCRIPTION
## Problem

When an alert has both a **Location** and **Visibility Pages** ("Show for the listed pages") configured, the Visibility Pages setting is ignored. The alert only appears on the location's own page, not on the pages listed in Visibility Pages.

If the Location is removed, Visibility Pages work correctly.

### Steps to reproduce

1. Create an alert
2. Select any location
3. Add pages in Visibility Pages and select "Show for the listed pages"
4. Save the alert
5. Open one of the pages listed in Visibility Pages

**Current result:** The alert is not shown on the Visibility Pages — it only appears on the location's own page

**Expected result:** The alert should be shown on the pages listed in Visibility Pages (in addition to the location page)

### Root cause

`getAlerts()` in `AlertManager` calls `getServiceAlerts()` to build a list of allowed alert IDs. For location-based alerts, `getServiceAlerts()` excludes them from the initial query (`notExists('field_alert_location')`) and relies on builder services (e.g. `BranchAlertBuilder`) to add them back — but only when the current page is the location's own page (bundle = `branch`).

So when the user is on a non-location page listed in Visibility Pages, the alert is not in `$service_alert_ids`, and the following check immediately skips it before `checkVisibility()` is ever called:

```php
if (!empty($service_alert_ids) && !in_array($alert->id(), $service_alert_ids)) {
    continue; // location alert always skipped here on non-location pages
}
```

## Solution

Before skipping the alert, check whether it has a Location assigned and passes `checkVisibility()` for the current page. If both conditions are true, the alert is allowed through.

```php
if (!empty($service_alert_ids) && !in_array($alert->id(), $service_alert_ids)) {
    $hasLocation = $alert->hasField('field_alert_location')
        && !$alert->field_alert_location->isEmpty();
    if (!$hasLocation || !$this->checkVisibility($alert, $node)) {
        continue;
    }
}
```

This preserves the existing behavior (location alerts only show on the location page by default) while allowing editors to extend visibility to additional pages via Visibility Pages.